### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.
release notes: https://github.com/actions/checkout/releases/tag/v5.0.0